### PR TITLE
Fix 'where Self:' warnings by splitting 'OrdSubsetSliceExt' up into 'OrdSubsetSliceExt' and 'OrdSubsetSliceExtMut'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //!
 //! ```
-//! use ord_subset::{OrdSubsetIterExt, OrdSubsetSliceExt};
+//! use ord_subset::{OrdSubsetIterExt, OrdSubsetSliceExt, OrdSubsetSliceExtMut};
 //!
 //! // Slices. Works on vector, too.
 //! let mut s = [5.0, std::f64::NAN, 3.0, 2.0];

--- a/src/slice_ext.rs
+++ b/src/slice_ext.rs
@@ -30,7 +30,7 @@ where
     }
 }
 
-pub trait OrdSubsetSliceExt<T> {
+pub trait OrdSubsetSliceExtMut<T>: AsMut<[T]> {
     /// Sort the slice. Values outside the ordered subset are put at the end in their original order.
     ///
     /// This is equivalent to `self.ord_subset_sort_by(|a,b| a.partial_cmp(b).unwrap())`
@@ -41,7 +41,6 @@ pub trait OrdSubsetSliceExt<T> {
     #[cfg(feature = "std")]
     fn ord_subset_sort(&mut self)
     where
-        Self: AsMut<[T]>,
         T: OrdSubset;
 
     /// Sort the slice in reverse order. Values outside the ordered subset are put at the end in their original order (i.e. not reversed).
@@ -52,7 +51,6 @@ pub trait OrdSubsetSliceExt<T> {
     #[cfg(feature = "std")]
     fn ord_subset_sort_rev(&mut self)
     where
-        Self: AsMut<[T]>,
         T: OrdSubset;
 
     /// Sorts the slice, using `compare` to order elements. Values outside the total order are put at the end in their original order.
@@ -70,7 +68,6 @@ pub trait OrdSubsetSliceExt<T> {
     #[cfg(feature = "std")]
     fn ord_subset_sort_by<F>(&mut self, compare: F)
     where
-        Self: AsMut<[T]>,
         T: OrdSubset,
         F: FnMut(&T, &T) -> Ordering;
 
@@ -82,7 +79,6 @@ pub trait OrdSubsetSliceExt<T> {
     #[cfg(feature = "std")]
     fn ord_subset_sort_by_key<B, F>(&mut self, f: F)
     where
-        Self: AsMut<[T]>,
         B: OrdSubset,
         F: FnMut(&T) -> B;
 
@@ -95,7 +91,6 @@ pub trait OrdSubsetSliceExt<T> {
     /// Panics when `a.partial_cmp(b)` returns `None` for two values `a`,`b` inside the total order (Violated OrdSubset contract).
     fn ord_subset_sort_unstable(&mut self)
     where
-        Self: AsMut<[T]>,
         T: OrdSubset;
 
     /// Sort the slice in reverse order. Values outside the ordered subset are put at the end.
@@ -105,7 +100,6 @@ pub trait OrdSubsetSliceExt<T> {
     /// Panics when `a.partial_cmp(b)` returns `None` for two values `a`,`b` inside the total order (Violated OrdSubset contract).
     fn ord_subset_sort_unstable_rev(&mut self)
     where
-        Self: AsMut<[T]>,
         T: OrdSubset;
 
     /// Sorts the slice, using `compare` to order elements. Values outside the total order are put at the end.
@@ -122,7 +116,6 @@ pub trait OrdSubsetSliceExt<T> {
     /// Panics when `a.partial_cmp(b)` returns `None` for two values `a`,`b` inside the total order (Violated OrdSubset contract).
     fn ord_subset_sort_unstable_by<F>(&mut self, compare: F)
     where
-        Self: AsMut<[T]>,
         T: OrdSubset,
         F: FnMut(&T, &T) -> Ordering;
 
@@ -133,9 +126,11 @@ pub trait OrdSubsetSliceExt<T> {
     /// time and space complexity of the current implementation.
     fn ord_subset_sort_unstable_by_key<B, F>(&mut self, f: F)
     where
-        Self: AsMut<[T]>,
         B: OrdSubset,
         F: FnMut(&T) -> B;
+}
+
+pub trait OrdSubsetSliceExt<T>: {
 
     /// Binary search a sorted slice for a given element. Values outside the ordered subset need to be at the end of the slice.
     ///
@@ -200,15 +195,14 @@ pub trait OrdSubsetSliceExt<T> {
         T: OrdSubset;
 }
 
-impl<T, U> OrdSubsetSliceExt<T> for U
+impl<T, U> OrdSubsetSliceExtMut<T> for U
 where
-    U: AsRef<[T]>,
+    U: AsMut<[T]>
 {
     #[cfg(feature = "std")]
     #[inline]
     fn ord_subset_sort(&mut self)
     where
-        U: AsMut<[T]>,
         T: OrdSubset,
     {
         self.as_mut().ord_subset_sort_by(|a, b| a.cmp_unwrap(b))
@@ -218,7 +212,6 @@ where
     #[inline]
     fn ord_subset_sort_by<F>(&mut self, mut compare: F)
     where
-        U: AsMut<[T]>,
         T: OrdSubset,
         F: FnMut(&T, &T) -> Ordering,
     {
@@ -230,7 +223,6 @@ where
     #[inline]
     fn ord_subset_sort_rev(&mut self)
     where
-        U: AsMut<[T]>,
         T: OrdSubset,
     {
         self.as_mut().ord_subset_sort_by(|a, b| b.cmp_unwrap(a))
@@ -240,7 +232,6 @@ where
     #[inline]
     fn ord_subset_sort_by_key<B, F>(&mut self, mut f: F)
     where
-        U: AsMut<[T]>,
         B: OrdSubset,
         F: FnMut(&T) -> B,
     {
@@ -251,7 +242,6 @@ where
     #[inline]
     fn ord_subset_sort_unstable(&mut self)
     where
-        U: AsMut<[T]>,
         T: OrdSubset,
     {
         self.as_mut()
@@ -261,7 +251,6 @@ where
     #[inline]
     fn ord_subset_sort_unstable_by<F>(&mut self, mut compare: F)
     where
-        U: AsMut<[T]>,
         T: OrdSubset,
         F: FnMut(&T, &T) -> Ordering,
     {
@@ -272,7 +261,6 @@ where
     #[inline]
     fn ord_subset_sort_unstable_rev(&mut self)
     where
-        U: AsMut<[T]>,
         T: OrdSubset,
     {
         self.as_mut()
@@ -282,7 +270,6 @@ where
     #[inline]
     fn ord_subset_sort_unstable_by_key<B, F>(&mut self, mut f: F)
     where
-        U: AsMut<[T]>,
         B: OrdSubset,
         F: FnMut(&T) -> B,
     {
@@ -290,7 +277,12 @@ where
             cmp_unordered_greater_all(&(f(a)), &(f(b)), CmpUnwrap::cmp_unwrap)
         })
     }
+}
 
+impl<T, U> OrdSubsetSliceExt<T> for U
+    where
+        U: AsRef<[T]>
+{
     #[inline]
     fn ord_subset_binary_search(&self, x: &T) -> Result<usize, usize>
     where

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,6 +3,7 @@ extern crate ord_subset;
 extern crate core;
 use ord_subset::OrdSubsetIterExt;
 use ord_subset::OrdSubsetSliceExt;
+use ord_subset::OrdSubsetSliceExtMut;
 use ord_subset::OrdSubset;
 use ord_subset::OrdVar;
 


### PR DESCRIPTION
This gets rid of a bunch of warnings such as:

    warning: the trait `slice_ext::OrdSubsetSliceExt` cannot be made into an object ord_subset, ord_subset
      --> src/slice_ext.rs:42:5
       |
    42 | /     fn ord_subset_sort(&mut self)
    43 | |     where
    44 | |         Self: AsMut<[T]>,
    45 | |         T: OrdSubset;
       | |_____________________^
       |
       = note: #[warn(where_clauses_object_safety)] on by default
       = warning: this was previously accepted by the compiler but is being phased out; it will become a      hard error in a future release!
       = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
       = note: method `ord_subset_sort` references the `Self` type in where clauses

The linked issue is https://github.com/rust-lang/rust/issues/51443. Unfortunately, the best solution I've been able to come up with so far is to split up `OrdSubsetSliceExt` into two traits, `OrdSubsetSliceExt`, and `OrdSubsetSliceExtMut` which requires `AsMut<[T]>`.