### PR TITLE
Fixes for latest `nighly` and some cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ord_subset"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Emerentius"]
-
+edition = "2018"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/emerentius/ord_subset"
 documentation = "https://docs.rs/ord_subset/"

--- a/src/iter_ext.rs
+++ b/src/iter_ext.rs
@@ -4,8 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ord_subset_trait::*;
-use ord_var::*;
+use crate::{ord_subset_trait::*, ord_var::*};
 
 /////////////////////////////////////////////////////////////////////
 pub trait OrdSubsetIterExt: Iterator //where Self::Item: OrdSubset
@@ -72,9 +71,9 @@ pub trait OrdSubsetIterExt: Iterator //where Self::Item: OrdSubset
     /// use ord_subset::OrdSubsetIterExt;
     ///
     /// fn main() {
-    /// 	let vec = vec![2.0, 3.0, 5.0, std::f64::NAN];
-    /// 	let min_by = vec.iter().ord_subset_min_by_key(|num| num.recip()).unwrap();
-    /// 	assert_eq!(&5.0, min_by);
+    ///     let vec = vec![2.0, 3.0, 5.0, std::f64::NAN];
+    ///     let min_by = vec.iter().ord_subset_min_by_key(|num| num.recip()).unwrap();
+    ///     assert_eq!(&5.0, min_by);
     /// }
     /// ```
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "cargo-clippy", allow(inline_always, match_bool))]
 //! Ever wanted to call `.max()` on an iterator of floats? Now you can! Well, almost: `.ord_subset_max()`.
 //!
 //! This crate is for types like the float primitive types `f32` and `f64`: Types that are totally ordered *except for these particular values*.
@@ -45,11 +44,11 @@
 extern crate core;
 
 mod iter_ext;
+mod ord_subset_trait;
 mod ord_var;
 mod slice_ext;
-mod ord_subset_trait;
 
 pub use iter_ext::*;
+pub use ord_subset_trait::*;
 pub use ord_var::*;
 pub use slice_ext::*;
-pub use ord_subset_trait::*;

--- a/src/ord_subset_trait.rs
+++ b/src/ord_subset_trait.rs
@@ -13,7 +13,7 @@ pub trait OrdSubset: PartialOrd<Self> + PartialEq<Self> {
     fn is_outside_order(&self) -> bool;
 }
 
-impl<'a, A> OrdSubset for &'a A
+impl<A> OrdSubset for &A
 where
     A: OrdSubset,
 {
@@ -23,7 +23,7 @@ where
     }
 }
 
-impl<'a, A> OrdSubset for &'a mut A
+impl<A> OrdSubset for &mut A
 where
     A: OrdSubset,
 {
@@ -33,7 +33,7 @@ where
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(float_cmp, eq_op))]
+#[allow(clippy::float_cmp, clippy::eq_op)]
 impl OrdSubset for f64 {
     #[inline(always)]
     fn is_outside_order(&self) -> bool {
@@ -42,7 +42,7 @@ impl OrdSubset for f64 {
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(float_cmp, eq_op))]
+#[allow(clippy::float_cmp, clippy::eq_op)]
 impl OrdSubset for f32 {
     #[inline(always)]
     fn is_outside_order(&self) -> bool {
@@ -71,7 +71,7 @@ macro_rules! impl_for_ord {
 	)
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 impl_for_ord!((), u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, bool, char);
 
 macro_rules! array_impls {
@@ -87,7 +87,7 @@ macro_rules! array_impls {
     }
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 array_impls!(
 	0, 1, 2, 3, 4, 5, 6, 7, 8,
 	9, 10, 11, 12, 13, 14, 15, 16,
@@ -110,7 +110,7 @@ macro_rules! tuple_impls {
         }
     )+) => {
         $(
-            impl<$($T:OrdSubset),+> OrdSubset for ($($T,)+) where last_type!($($T,)+): ?Sized {
+            impl<$($T:OrdSubset),+> OrdSubset for ($($T,)+) {
                 #[inline]
                 fn is_outside_order(&self) -> bool {
                     $(self.$idx.is_outside_order())||+
@@ -249,13 +249,13 @@ mod test {
     use super::OrdSubset;
     #[test]
     fn heterogenous_tuple() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let tup = ((), 0u8, 0u16, 0u32, 0u64, 0usize, 0i8, 0i16, 0i32, 0i64, 0isize, 'a');
         assert!(!tup.is_outside_order());
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn slice() {
         let a = [0u8; 32];
         assert!( ! a.is_outside_order() );

--- a/src/ord_var.rs
+++ b/src/ord_var.rs
@@ -4,10 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::cmp::Ordering;
-use core::fmt::Debug;
-use ord_subset_trait::*;
-use core::ops::Deref;
+use crate::ord_subset_trait::*;
+use core::{cmp::Ordering, fmt::Debug, ops::Deref};
 
 /// Wrapper to signal that the contained variables have a total order. It's illegal to compare two `OrdVar`s that are not ordered.
 /// For this reason, it's unsafe to create `OrdVar`s without checking. Checked constructors are available for `OrdSubset` types.
@@ -30,10 +28,7 @@ impl<T: PartialOrd + PartialEq> OrdVar<T> {
         T: Debug + OrdSubset,
     {
         if data.is_outside_order() {
-            panic!(
-                "Attempted saving data outside of total order into OrdVar: {:?}",
-                data
-            )
+            panic!("{}", "Attempted saving data outside of total order into OrdVar: {data:?}")
         };
         OrdVar(data)
     }
@@ -99,12 +94,12 @@ impl<T: Default + OrdSubset + Debug> Default for OrdVar<T> {
 #[cfg(feature = "ops")]
 mod ops {
     // would love to be able to macro these away somehow
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
 	use core::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr, Neg, Not,
                 AddAssign, SubAssign, MulAssign, DivAssign, RemAssign, BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign,};
-    use core::fmt::Debug;
-    use ord_subset_trait::*;
     use super::OrdVar;
+    use crate::ord_subset_trait::*;
+    use core::fmt::Debug;
 
     #[inline(always)]
     fn construct<T: OrdSubset + Debug>(t: T) -> OrdVar<T> {

--- a/src/slice_ext.rs
+++ b/src/slice_ext.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ord_subset_trait::*;
+use crate::ord_subset_trait::*;
 use core::cmp::Ordering::{self, Equal, Greater, Less};
 
 static ERROR_BINARY_SEARCH_OUTSIDE_ORDER: &str =
@@ -156,7 +156,7 @@ pub trait OrdSubsetSliceExt<T> {
     /// assert_eq!(s.ord_subset_binary_search(&100.), Err(13));
     /// let r = s.ord_subset_binary_search(&1.);
     /// assert!(match r { Ok(1...4) => true, _ => false, });
-    ///	assert_eq!(s.ord_subset_binary_search(&f64::INFINITY), Err(13));
+    /// assert_eq!(s.ord_subset_binary_search(&f64::INFINITY), Err(13));
     /// ```
     ///
     /// # Panics
@@ -297,7 +297,7 @@ where
         T: OrdSubset,
     {
         if x.is_outside_order() {
-            panic!(ERROR_BINARY_SEARCH_OUTSIDE_ORDER)
+            panic!("{}", ERROR_BINARY_SEARCH_OUTSIDE_ORDER)
         };
         self.ord_subset_binary_search_by(|other| {
             other.partial_cmp(x).expect(ERROR_BINARY_SEARCH_EXPECT)
@@ -325,7 +325,7 @@ where
         F: FnMut(&T) -> B,
     {
         if b.is_outside_order() {
-            panic!(ERROR_BINARY_SEARCH_OUTSIDE_ORDER)
+            panic!("{}", ERROR_BINARY_SEARCH_OUTSIDE_ORDER)
         };
         // compare ordered values as expected
         // wrap it in a function that deals with unordered, so this one never sees them
@@ -340,7 +340,7 @@ where
         T: OrdSubset,
     {
         if x.is_outside_order() {
-            panic!(ERROR_BINARY_SEARCH_OUTSIDE_ORDER)
+            panic!("{}", ERROR_BINARY_SEARCH_OUTSIDE_ORDER)
         };
         self.ord_subset_binary_search_by(|other| {
             x.partial_cmp(other).expect(ERROR_BINARY_SEARCH_EXPECT)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(feature = "cargo-clippy", allow(float_cmp, match_wild_err_arm))]
-extern crate ord_subset;
 extern crate core;
+extern crate ord_subset;
+use ord_subset::OrdSubset;
 use ord_subset::OrdSubsetIterExt;
 use ord_subset::OrdSubsetSliceExt;
-use ord_subset::OrdSubset;
 use ord_subset::OrdVar;
 
 use std::f64::INFINITY as INF;
@@ -12,31 +12,26 @@ use std::f64::NAN;
 const N: usize = 32;
 const N_NO_NAN: usize = 30;
 
-const TEST_ARRAY: [f64; N] =
-	[1.0,  7.0,  26.0,  INF,  NAN,  0.0, 14.0, 17.0,
-	27.0, 13.0,  10.0,  3.0,  NAN, 25.0,  9.0, 20.0,
-	16.0,  8.0,  -INF,  4.0,  2.0, 22.0, 18.0, 21.0,
-	15.0,  6.0,  24.0, 19.0, 12.0, 11.0,  5.0, 23.0];
+const TEST_ARRAY: [f64; N] = [
+    1.0, 7.0, 26.0, INF, NAN, 0.0, 14.0, 17.0, 27.0, 13.0, 10.0, 3.0, NAN, 25.0, 9.0, 20.0, 16.0,
+    8.0, -INF, 4.0, 2.0, 22.0, 18.0, 21.0, 15.0, 6.0, 24.0, 19.0, 12.0, 11.0, 5.0, 23.0,
+];
 
 // subset of TEST_ARRAY
-const TEST_ARRAY_NO_NAN: [f64; N_NO_NAN] =
-	[1.0,  7.0,  26.0,  INF,        0.0, 14.0, 17.0,
-	27.0, 13.0,  10.0,  3.0,       25.0,  9.0, 20.0,
-	16.0,  8.0,  -INF,  4.0,  2.0, 22.0, 18.0, 21.0,
-	15.0,  6.0,  24.0, 19.0, 12.0, 11.0,  5.0, 23.0];
+const TEST_ARRAY_NO_NAN: [f64; N_NO_NAN] = [
+    1.0, 7.0, 26.0, INF, 0.0, 14.0, 17.0, 27.0, 13.0, 10.0, 3.0, 25.0, 9.0, 20.0, 16.0, 8.0, -INF,
+    4.0, 2.0, 22.0, 18.0, 21.0, 15.0, 6.0, 24.0, 19.0, 12.0, 11.0, 5.0, 23.0,
+];
 
-const SORTED_TEST_ARRAY: [f64; N] =
-	[-INF, 0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,
-	 7.0,  8.0,  9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
-	15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0,
-	23.0, 24.0, 25.0, 26.0, 27.0,  INF,  NAN,  NAN];
+const SORTED_TEST_ARRAY: [f64; N] = [
+    -INF, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+    16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, INF, NAN, NAN,
+];
 
-const SORTED_TEST_ARRAY_NO_NAN: [f64; N_NO_NAN] =
-	[-INF, 0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,
-	 7.0,  8.0,  9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
-	15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0,
-	23.0, 24.0, 25.0, 26.0, 27.0, INF             ];
-
+const SORTED_TEST_ARRAY_NO_NAN: [f64; N_NO_NAN] = [
+    -INF, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+    16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, INF,
+];
 
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
 struct NotOrdSub();
@@ -44,39 +39,39 @@ struct NotOrdSub();
 struct OrdSub();
 
 impl OrdSubset for OrdSub {
-	fn is_outside_order(&self) -> bool {
-		true
-	}
+    fn is_outside_order(&self) -> bool {
+        true
+    }
 }
 
 // ---------------------------- iter ext methods -------------------------------
 
 #[test]
 fn ord_subset_max() {
-	let arr = [2.0, 3.0, 5.0, std::f64::NAN];
-	let max = arr.iter().ord_subset_max().unwrap();
-	assert_eq!(&5.0, max);
+    let arr = [2.0, 3.0, 5.0, std::f64::NAN];
+    let max = arr.iter().ord_subset_max().unwrap();
+    assert_eq!(&5.0, max);
 }
 
 #[test]
 fn ord_subset_max_by() {
-	let arr = [2.0, 3.0, 5.0, std::f64::NAN];
-	let max_by = arr.iter().ord_subset_max_by_key(|num| num.recip()).unwrap();
-	assert_eq!(&2.0, max_by);
+    let arr = [2.0, 3.0, 5.0, std::f64::NAN];
+    let max_by = arr.iter().ord_subset_max_by_key(|num| num.recip()).unwrap();
+    assert_eq!(&2.0, max_by);
 }
 
 #[test]
 fn ord_subset_min() {
-	let arr = [2.0, 3.0, 5.0, std::f64::NAN];
-	let min = arr.iter().ord_subset_min().unwrap();
-	assert_eq!(&2.0, min);
+    let arr = [2.0, 3.0, 5.0, std::f64::NAN];
+    let min = arr.iter().ord_subset_min().unwrap();
+    assert_eq!(&2.0, min);
 }
 
 #[test]
 fn ord_subset_min_by() {
-	let arr = [2.0, 3.0, 5.0, std::f64::NAN];
-	let min_by = arr.iter().ord_subset_min_by_key(|num| num.recip()).unwrap();
-	assert_eq!(&5.0, min_by);
+    let arr = [2.0, 3.0, 5.0, std::f64::NAN];
+    let min_by = arr.iter().ord_subset_min_by_key(|num| num.recip()).unwrap();
+    assert_eq!(&5.0, min_by);
 }
 
 // This is a compile time test. It can't fail at runtime.
@@ -84,168 +79,160 @@ fn ord_subset_min_by() {
 // if the closure produces OrdSubset values
 #[allow(unused)]
 fn ord_subset_min_or_max_by_key() {
-	let array: [NotOrdSub; 0] = [];
-	array.iter().ord_subset_min_by_key(|_| 0.0);
-	array.iter().ord_subset_max_by_key(|_| 0.0);
+    let array: [NotOrdSub; 0] = [];
+    array.iter().ord_subset_min_by_key(|_| 0.0);
+    array.iter().ord_subset_max_by_key(|_| 0.0);
 }
 
 // ---------------------------slice ext methods --------------------------------
 // ----------------------------- stable sorts ----------------------------------
 
 #[test]
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 fn sort() {
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort();
-	assert_eq!(&array[0..N_NO_NAN], &SORTED_TEST_ARRAY_NO_NAN);
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort();
+    assert_eq!(&array[0..N_NO_NAN], &SORTED_TEST_ARRAY_NO_NAN);
 }
 
 #[test]
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 fn sort_rev() {
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_rev();
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_rev();
 
-	let mut rev_sorted_array = SORTED_TEST_ARRAY_NO_NAN;
-	rev_sorted_array.reverse();
+    let mut rev_sorted_array = SORTED_TEST_ARRAY_NO_NAN;
+    rev_sorted_array.reverse();
 
-	assert_eq!(&array[0..N_NO_NAN], &rev_sorted_array);
+    assert_eq!(&array[0..N_NO_NAN], &rev_sorted_array);
 }
 
 #[test]
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 fn sort_by_key() {
-	fn key_function(el: &f64) -> f64 {
-		(el - 13.0).recip()
-	}
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_by_key(key_function);
-	let mut std_sorted_array = TEST_ARRAY_NO_NAN;
-	std_sorted_array.sort_by_key(|num| OrdVar::new(key_function(num)));
-	assert_eq!(&array[..N_NO_NAN], &std_sorted_array);
+    fn key_function(el: &f64) -> f64 {
+        (el - 13.0).recip()
+    }
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_by_key(key_function);
+    let mut std_sorted_array = TEST_ARRAY_NO_NAN;
+    std_sorted_array.sort_by_key(|num| OrdVar::new(key_function(num)));
+    assert_eq!(&array[..N_NO_NAN], &std_sorted_array);
 }
 
 // ----------------------------- unstable sorts --------------------------------
 
 #[test]
 fn sort_unstable() {
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable();
-	assert_eq!(&array[0..N_NO_NAN], &SORTED_TEST_ARRAY_NO_NAN);
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable();
+    assert_eq!(&array[0..N_NO_NAN], &SORTED_TEST_ARRAY_NO_NAN);
 }
 
 #[test]
 fn sort_unstable_rev() {
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable_rev();
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable_rev();
 
-	let mut rev_sorted_array = SORTED_TEST_ARRAY_NO_NAN;
-	rev_sorted_array.reverse();
+    let mut rev_sorted_array = SORTED_TEST_ARRAY_NO_NAN;
+    rev_sorted_array.reverse();
 
-	assert_eq!(&array[0..N_NO_NAN], &rev_sorted_array);
+    assert_eq!(&array[0..N_NO_NAN], &rev_sorted_array);
 }
 
 #[test]
 fn sort_unstable_by_key() {
-	fn key_function(el: &f64) -> f64 {
-		(el - 13.0).recip()
-	}
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable_by_key(key_function);
-	let mut std_sorted_array = TEST_ARRAY_NO_NAN;
-	std_sorted_array.sort_unstable_by_key(|num| OrdVar::new(key_function(num)));
-	assert_eq!(&array[..N_NO_NAN], &std_sorted_array);
+    fn key_function(el: &f64) -> f64 {
+        (el - 13.0).recip()
+    }
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable_by_key(key_function);
+    let mut std_sorted_array = TEST_ARRAY_NO_NAN;
+    std_sorted_array.sort_unstable_by_key(|num| OrdVar::new(key_function(num)));
+    assert_eq!(&array[..N_NO_NAN], &std_sorted_array);
 }
 
 // ---------------------------- binary searches --------------------------------
 
 #[test]
 fn binary_search() {
-	let array = SORTED_TEST_ARRAY;
-	for (i, num) in array.iter().enumerate().take(N_NO_NAN) {
-		assert_eq!(array.ord_subset_binary_search(num), Ok(i));
-	}
+    let array = SORTED_TEST_ARRAY;
+    for (i, num) in array.iter().enumerate().take(N_NO_NAN) {
+        assert_eq!(array.ord_subset_binary_search(num), Ok(i));
+    }
 }
 
 #[test]
 fn binary_search_rev() {
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable_rev();
-	for (i, num) in array.iter().enumerate().take(N_NO_NAN) {
-		assert_eq!(array.ord_subset_binary_search_rev(num), Ok(i));
-	}
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable_rev();
+    for (i, num) in array.iter().enumerate().take(N_NO_NAN) {
+        assert_eq!(array.ord_subset_binary_search_rev(num), Ok(i));
+    }
 }
 
 #[test]
 fn binary_search_by_key() {
-	fn key_function(el: &f64) -> f64 {
-		(el - 13.0).recip()
-	}
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable_by_key(key_function);
-	for num in array.iter().take(N_NO_NAN) {
-		let key = key_function(num);
-		match array.ord_subset_binary_search_by_key(&key, key_function) {
-			Err(_) => panic!("Did not find correct location of element"),
-			Ok(pos) => assert_eq!(key_function(&array[pos]), key),
-		}
-	}
+    fn key_function(el: &f64) -> f64 {
+        (el - 13.0).recip()
+    }
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable_by_key(key_function);
+    for num in array.iter().take(N_NO_NAN) {
+        let key = key_function(num);
+        match array.ord_subset_binary_search_by_key(&key, key_function) {
+            Err(_) => panic!("Did not find correct location of element"),
+            Ok(pos) => assert_eq!(key_function(&array[pos]), key),
+        }
+    }
 }
 
 // ------ binary search error cases ------
 
 #[test]
 fn binary_search_err() {
-	let array = SORTED_TEST_ARRAY;
-	for (i, num) in array.iter()
-		.enumerate()
-		.filter(|&(_, num)| num.is_finite())
-	{
-		let new_num = num + 0.5;
-		assert_eq!(array.ord_subset_binary_search(&new_num), Err(i+1));
-	}
+    let array = SORTED_TEST_ARRAY;
+    for (i, num) in array.iter().enumerate().filter(|&(_, num)| num.is_finite()) {
+        let new_num = num + 0.5;
+        assert_eq!(array.ord_subset_binary_search(&new_num), Err(i + 1));
+    }
 }
 
 #[test]
 fn binary_search_rev_err() {
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable_rev();
-	for (i, num) in array.iter()
-		.enumerate()
-		.filter(|&(_, num)| num.is_finite())
-	{
-		let new_num = num + 0.5;
-		assert_eq!(array.ord_subset_binary_search_rev(&new_num), Err(i));
-	}
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable_rev();
+    for (i, num) in array.iter().enumerate().filter(|&(_, num)| num.is_finite()) {
+        let new_num = num + 0.5;
+        assert_eq!(array.ord_subset_binary_search_rev(&new_num), Err(i));
+    }
 }
 
 #[test]
 fn binary_search_by_key_err() {
-	fn key_function(el: &f64) -> f64 {
-		(el - 13.0).recip()
-	}
-	let mut array = TEST_ARRAY;
-	array.ord_subset_sort_unstable_by_key(key_function);
-	for num in array.iter().take(N_NO_NAN) {
-		let key_diff = key_function(&(num+0.01))*1.01 + 0.01;
-		let pos = array.ord_subset_binary_search_by_key(&key_diff, key_function);
-		let pos_std = (&array[..N_NO_NAN]).binary_search_by_key(
-			&OrdVar::new(key_diff),
-			|num| OrdVar::new(key_function(num))
-		);
-		match (pos, pos_std) {
-			(Err(pos), Err(pos_std)) => assert!(pos == pos_std),
-			// the commented out match branch is also valid behaviour
-			// but this function is supposed to test as many error cases as possible
-			// by choosing key_diff the right way
-			//(Ok(pos), Ok(pos_std)) => {
-			//	let key1 = key_function(&array[pos]);
-			//	let key2 = key_function(&array[pos_std]);
-			//	assert!(key1 == key2);
-			//},
-			_ => panic!("Inconsistency between this library's and std's binary_search_by_key"),
-		}
-	}
+    fn key_function(el: &f64) -> f64 {
+        (el - 13.0).recip()
+    }
+    let mut array = TEST_ARRAY;
+    array.ord_subset_sort_unstable_by_key(key_function);
+    for num in array.iter().take(N_NO_NAN) {
+        let key_diff = key_function(&(num + 0.01)) * 1.01 + 0.01;
+        let pos = array.ord_subset_binary_search_by_key(&key_diff, key_function);
+        let pos_std = (&array[..N_NO_NAN])
+            .binary_search_by_key(&OrdVar::new(key_diff), |num| OrdVar::new(key_function(num)));
+        match (pos, pos_std) {
+            (Err(pos), Err(pos_std)) => assert!(pos == pos_std),
+            // the commented out match branch is also valid behaviour
+            // but this function is supposed to test as many error cases as possible
+            // by choosing key_diff the right way
+            //(Ok(pos), Ok(pos_std)) => {
+            //	let key1 = key_function(&array[pos]);
+            //	let key2 = key_function(&array[pos_std]);
+            //	assert!(key1 == key2);
+            //},
+            _ => panic!("Inconsistency between this library's and std's binary_search_by_key"),
+        }
+    }
 }
 
 // -------------------- compile time implementation tests ----------------------
@@ -254,142 +241,144 @@ fn binary_search_by_key_err() {
 // all implement the OrdSubsetSliceExt trait, no matter the mutability.
 #[allow(unused)]
 fn ord_subset_slice_ext_impl_test() {
-	fn foo<T: OrdSubsetSliceExt<U> + AsRef<[U]>, U: OrdSubset + Clone>(as_slice: T) {
-		// would panic, good thing it doesn't run
-		let element: &U = as_slice.as_ref().first().unwrap();
-		as_slice.ord_subset_binary_search(element);
-		as_slice.ord_subset_binary_search_rev(element);
-		as_slice.ord_subset_binary_search_by_key(element, |_| element.clone());
-		as_slice.ord_subset_binary_search_by(|_| std::cmp::Ordering::Equal);
-	}
+    fn foo<T: OrdSubsetSliceExt<U> + AsRef<[U]>, U: OrdSubset + Clone>(as_slice: T) {
+        // would panic, good thing it doesn't run
+        let element: &U = as_slice.as_ref().first().unwrap();
+        as_slice.ord_subset_binary_search(element);
+        as_slice.ord_subset_binary_search_rev(element);
+        as_slice.ord_subset_binary_search_by_key(element, |_| element.clone());
+        as_slice.ord_subset_binary_search_by(|_| std::cmp::Ordering::Equal);
+    }
 
-	let mut vec: Vec<OrdSub> = vec![];
-	let mut arr: [OrdSub; 0] = [];
+    let mut vec: Vec<OrdSub> = vec![];
+    let mut arr: [OrdSub; 0] = [];
 
-	// &vec
-	foo(&vec);
-	foo(&mut vec);
+    // &vec
+    foo(&vec);
+    foo(&mut vec);
 
-	// &array
-	foo(&arr);
-	foo(&mut arr);
+    // &array
+    foo(&arr);
+    foo(&mut arr);
 
-	// &slice
-	foo(&arr[..]);
-	foo(&mut arr[..]);
+    // &slice
+    foo(&arr[..]);
+    foo(&mut arr[..]);
 
-	// &&slice
-	foo(&&arr[..]);
-	foo(&mut &mut arr[..]);
-	foo(& &mut arr[..]);
+    // &&slice
+    foo(&&arr[..]);
+    foo(&mut &mut arr[..]);
+    foo(&&mut arr[..]);
 
-	// owned
-	foo(vec);
-	foo(arr);
+    // owned
+    foo(vec);
+    foo(arr);
 }
 
 // check that mutable vecs, arrays and slices are all sortable
 #[allow(unused)]
 fn ord_subset_mut_slice_ext_impl_test() {
-	fn sortable<T, U>(mut as_slice: T)
-		where T: OrdSubsetSliceExt<U> + AsMut<[U]>,
-		      U: OrdSubset,
-	{
-		#[cfg(feature="std")]
-		as_slice.ord_subset_sort();
-		#[cfg(feature="std")]
-		as_slice.ord_subset_sort_rev();
-		#[cfg(feature="std")]
-		as_slice.ord_subset_sort_by(|_, _| core::cmp::Ordering::Equal);
-		#[cfg(feature="std")]
-		as_slice.ord_subset_sort_by_key(|_| 0.0);
+    fn sortable<T, U>(mut as_slice: T)
+    where
+        T: OrdSubsetSliceExt<U> + AsMut<[U]>,
+        U: OrdSubset,
+    {
+        #[cfg(feature = "std")]
+        as_slice.ord_subset_sort();
+        #[cfg(feature = "std")]
+        as_slice.ord_subset_sort_rev();
+        #[cfg(feature = "std")]
+        as_slice.ord_subset_sort_by(|_, _| core::cmp::Ordering::Equal);
+        #[cfg(feature = "std")]
+        as_slice.ord_subset_sort_by_key(|_| 0.0);
 
-		as_slice.ord_subset_sort_unstable();
-		as_slice.ord_subset_sort_unstable_rev();
-		as_slice.ord_subset_sort_unstable_by(|_, _| core::cmp::Ordering::Equal);
-		as_slice.ord_subset_sort_unstable_by_key(|_| 0.0);
-	}
+        as_slice.ord_subset_sort_unstable();
+        as_slice.ord_subset_sort_unstable_rev();
+        as_slice.ord_subset_sort_unstable_by(|_, _| core::cmp::Ordering::Equal);
+        as_slice.ord_subset_sort_unstable_by_key(|_| 0.0);
+    }
 
-	let mut vec: Vec<OrdSub> = vec![];
-	let mut arr: [OrdSub; 0] = [];
+    let mut vec: Vec<OrdSub> = vec![];
+    let mut arr: [OrdSub; 0] = [];
 
-	sortable(&mut vec);
-	sortable(&mut arr);
-	sortable(&mut arr[..]);
-	sortable(&mut &mut arr[..]);
-	// owned
-	sortable(vec);
-	sortable(arr);
+    sortable(&mut vec);
+    sortable(&mut arr);
+    sortable(&mut arr[..]);
+    sortable(&mut &mut arr[..]);
+    // owned
+    sortable(vec);
+    sortable(arr);
 }
 
 // check that slices, arrays and vecs as well as references of non-OrdSubset items
 // all implement the OrdSubsetSliceExt trait and allow binary_search_by_key.
 #[allow(unused)]
 fn non_ord_subset_slice_ext_impl_test() {
-	/*
-	fn foo<T: OrdSubsetSliceExt<U> + AsRef<[U]>, U: Clone>(as_slice: T) {
-		// would panic, good thing it doesn't run
-		let element: &U = as_slice.as_ref().first().unwrap();
-		as_slice.ord_subset_binary_search(element);
-		as_slice.ord_subset_binary_search_rev(element);
-		as_slice.ord_subset_binary_search_by_key(element, |_| element.clone());
-		as_slice.ord_subset_binary_search_by(|_| std::cmp::Ordering::Equal);
-	}
-	*/
-	fn foo<T: OrdSubsetSliceExt<U> + AsRef<[U]>, U>(as_slice: T) {
-		let key = OrdSub();
-		as_slice.ord_subset_binary_search_by_key(&key, |_| key);
-	}
+    /*
+    fn foo<T: OrdSubsetSliceExt<U> + AsRef<[U]>, U: Clone>(as_slice: T) {
+        // would panic, good thing it doesn't run
+        let element: &U = as_slice.as_ref().first().unwrap();
+        as_slice.ord_subset_binary_search(element);
+        as_slice.ord_subset_binary_search_rev(element);
+        as_slice.ord_subset_binary_search_by_key(element, |_| element.clone());
+        as_slice.ord_subset_binary_search_by(|_| std::cmp::Ordering::Equal);
+    }
+    */
+    fn foo<T: OrdSubsetSliceExt<U> + AsRef<[U]>, U>(as_slice: T) {
+        let key = OrdSub();
+        as_slice.ord_subset_binary_search_by_key(&key, |_| key);
+    }
 
-	let mut vec: Vec<NotOrdSub> = vec![];
-	let mut arr: [NotOrdSub; 0] = [];
+    let mut vec: Vec<NotOrdSub> = vec![];
+    let mut arr: [NotOrdSub; 0] = [];
 
-	// &vec
-	foo(&vec);
-	foo(&mut vec);
+    // &vec
+    foo(&vec);
+    foo(&mut vec);
 
-	// &array
-	foo(&arr);
-	foo(&mut arr);
+    // &array
+    foo(&arr);
+    foo(&mut arr);
 
-	// &slice
-	foo(&arr[..]);
-	foo(&mut arr[..]);
+    // &slice
+    foo(&arr[..]);
+    foo(&mut arr[..]);
 
-	// &&slice
-	foo(&&arr[..]);
-	foo(&mut &mut arr[..]);
-	foo(& &mut arr[..]);
+    // &&slice
+    foo(&&arr[..]);
+    foo(&mut &mut arr[..]);
+    foo(&&mut arr[..]);
 
-	// owned
-	foo(vec);
-	foo(arr);
+    // owned
+    foo(vec);
+    foo(arr);
 }
 
 // check that mutable vecs, arrays and slices of non-OrdSubset types are all sortable by key
 #[allow(unused)]
 fn non_ord_subset_mut_slice_ext_impl_test() {
-	fn sortable<T, U>(mut as_slice: T)
-		where T: OrdSubsetSliceExt<U> + AsMut<[U]>,
-	{
-		let key = OrdSub();
+    fn sortable<T, U>(mut as_slice: T)
+    where
+        T: OrdSubsetSliceExt<U> + AsMut<[U]>,
+    {
+        let key = OrdSub();
 
-		#[cfg(feature="std")]
-		as_slice.ord_subset_sort_by_key(|_| key);
+        #[cfg(feature = "std")]
+        as_slice.ord_subset_sort_by_key(|_| key);
 
-		as_slice.ord_subset_sort_unstable_by_key(|_| key);
-	}
+        as_slice.ord_subset_sort_unstable_by_key(|_| key);
+    }
 
-	let mut vec: Vec<NotOrdSub> = vec![];
-	let mut arr: [NotOrdSub; 0] = [];
+    let mut vec: Vec<NotOrdSub> = vec![];
+    let mut arr: [NotOrdSub; 0] = [];
 
-	sortable(&mut vec);
-	sortable(&mut arr);
-	sortable(&mut arr[..]);
-	sortable(&mut &mut arr[..]);
-	// owned
-	sortable(vec);
-	sortable(arr);
+    sortable(&mut vec);
+    sortable(&mut arr);
+    sortable(&mut arr[..]);
+    sortable(&mut &mut arr[..]);
+    // owned
+    sortable(vec);
+    sortable(arr);
 }
 
 // std-library bug: https://github.com/rust-lang/rust/issues/34683
@@ -397,10 +386,10 @@ fn non_ord_subset_mut_slice_ext_impl_test() {
 // this test is a compile test, it can't fail at runtime
 #[test]
 fn binary_search_lifetime() {
-	#[derive(Debug)]
-	struct Foo {
-    	property: f32,
-	}
+    #[derive(Debug)]
+    struct Foo {
+        property: f32,
+    }
 
     let xs = vec![
         Foo { property: 1. },
@@ -411,77 +400,107 @@ fn binary_search_lifetime() {
     let _r = xs.ord_subset_binary_search_by_key(&2., |entry| entry.property);
 }
 
-#[cfg(feature="ops")]
-use core::ops::{Add, Sub, Mul, Div, Rem,
-	//BitAnd, BitOr, BitXor, Shl, Shr,
-	Neg, //Not,
-	AddAssign, SubAssign, MulAssign, DivAssign, RemAssign,
-	//BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign,
+#[cfg(feature = "ops")]
+use core::ops::{
+    Add,
+    AddAssign,
+    Div,
+    DivAssign,
+    Mul,
+    MulAssign,
+    //BitAnd, BitOr, BitXor, Shl, Shr,
+    Neg, //Not,
+    Rem,
+    RemAssign,
+    //BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign,
+    Sub,
+    SubAssign,
 };
 
 #[test]
-#[cfg(feature="ops")]
+#[cfg(feature = "ops")]
 fn ops_correctness_test() {
-	let infix_ops = [
-		Add::add, Sub::sub, Mul::mul, Div::div, Rem::rem,
-		//BitAnd::bitand, BitOr::bitor, BitXor::bitxor, Shl::shl, Shr::shr
-	];
+    let infix_ops = [
+        Add::add,
+        Sub::sub,
+        Mul::mul,
+        Div::div,
+        Rem::rem,
+        //BitAnd::bitand, BitOr::bitor, BitXor::bitxor, Shl::shl, Shr::shr
+    ];
 
-	let unary_ops = [
-		Neg::neg,
-		//Not::not
-	];
-	let assign_ops = [
-		AddAssign::add_assign, SubAssign::sub_assign, MulAssign::mul_assign, DivAssign::div_assign, RemAssign::rem_assign,
-		//BitAndAssign::bitand_assign, BitOrAssign::bitor_assign, BitXorAssign::bitxor_assign,
-		//ShlAssign::shl_assign, ShrAssign::shr_assign
-	];
+    let unary_ops = [
+        Neg::neg,
+        //Not::not
+    ];
+    let assign_ops = [
+        AddAssign::add_assign,
+        SubAssign::sub_assign,
+        MulAssign::mul_assign,
+        DivAssign::div_assign,
+        RemAssign::rem_assign,
+        //BitAndAssign::bitand_assign, BitOrAssign::bitor_assign, BitXorAssign::bitxor_assign,
+        //ShlAssign::shl_assign, ShrAssign::shr_assign
+    ];
 
-	// same functions but for OrdVar variables
-	let infix_ops_ordvar = [
-		Add::add, Sub::sub, Mul::mul, Div::div, Rem::rem,
-		//BitAnd::bitand, BitOr::bitor, BitXor::bitxor, Shl::shl, Shr::shr
-	];
+    // same functions but for OrdVar variables
+    let infix_ops_ordvar = [
+        Add::add,
+        Sub::sub,
+        Mul::mul,
+        Div::div,
+        Rem::rem,
+        //BitAnd::bitand, BitOr::bitor, BitXor::bitxor, Shl::shl, Shr::shr
+    ];
 
-	let unary_ops_ordvar = [
-		Neg::neg,
-		//Not::not
-	];
+    let unary_ops_ordvar = [
+        Neg::neg,
+        //Not::not
+    ];
 
-	let assign_ops_ordvar = [
-		AddAssign::add_assign, SubAssign::sub_assign, MulAssign::mul_assign, DivAssign::div_assign, RemAssign::rem_assign,
-		//BitAndAssign::bitand_assign, BitOrAssign::bitor_assign, BitXorAssign::bitxor_assign,
-		//ShlAssign::shl_assign, ShrAssign::shr_assign
-	];
+    let assign_ops_ordvar = [
+        AddAssign::add_assign,
+        SubAssign::sub_assign,
+        MulAssign::mul_assign,
+        DivAssign::div_assign,
+        RemAssign::rem_assign,
+        //BitAndAssign::bitand_assign, BitOrAssign::bitor_assign, BitXorAssign::bitxor_assign,
+        //ShlAssign::shl_assign, ShrAssign::shr_assign
+    ];
 
-	// skip 0, can't divide by it
-	let nums = (-10..0).chain(1..11i32).map(|n| n as f64).collect::<Vec<_>>();
-	let combinations = nums.iter().flat_map(|&n1| nums.iter().map(move |&n2| (n1, n2)));
+    // skip 0, can't divide by it
+    let nums = (-10..0)
+        .chain(1..11i32)
+        .map(|n| n as f64)
+        .collect::<Vec<_>>();
+    let combinations = nums
+        .iter()
+        .flat_map(|&n1| nums.iter().map(move |&n2| (n1, n2)));
 
-	for (num1, num2) in combinations {
-		// infix ops
-		for (op, op_ordvar) in infix_ops.iter().zip(infix_ops_ordvar.iter()) {
-			let res = op(num1, num2);
-			let res2 = op_ordvar(OrdVar::new(num1), num2);
-			//let res2 = op_ordvar(num1, num2);
-			assert!(res == res2.into_inner())
-		}
+    for (num1, num2) in combinations {
+        // infix ops
+        for (op, op_ordvar) in infix_ops.iter().zip(infix_ops_ordvar.iter()) {
+            let res = op(num1, num2);
+            let res2 = op_ordvar(OrdVar::new(num1), num2);
+            //let res2 = op_ordvar(num1, num2);
+            assert!(res == res2.into_inner())
+        }
 
-		// unary ops
-		for (op, op_ordvar) in unary_ops.iter().zip(unary_ops_ordvar.iter()) {
-			let res = op(num1);
-			let res2 = op_ordvar(OrdVar::new(num1));
-			//let res2 = op_ordvar(num1, num2);
-			assert!(res == res2.into_inner())
-		}
+        // unary ops
+        for (op, op_ordvar) in unary_ops.iter().zip(unary_ops_ordvar.iter()) {
+            let res = op(num1);
+            let res2 = op_ordvar(OrdVar::new(num1));
+            //let res2 = op_ordvar(num1, num2);
+            assert!(res == res2.into_inner())
+        }
 
-		// assign ops
-		for (op, op_ordvar) in assign_ops.iter().zip(assign_ops_ordvar.iter()) {
-			let mut num1 = num1;
-			let mut ordvar = OrdVar::new(num1);
-			op(&mut num1, num2);
-			op_ordvar(&mut ordvar, num2);
-			assert!(num1 == ordvar.into_inner())
-		}
-	}
+        // assign ops
+        for (op, op_ordvar) in assign_ops.iter().zip(assign_ops_ordvar.iter()) {
+            let mut num1 = num1;
+            let mut ordvar = OrdVar::new(num1);
+            op(&mut num1, num2);
+            op_ordvar(&mut ordvar, num2);
+            assert!(num1 == ordvar.into_inner())
+        }
+    }
 }


### PR DESCRIPTION
* removed `Sized?` req. from tuple macro for nightly-compatibility
* set edition to 2018 (was undefined)
* made `clippy` (mostly) happy
* fixed `crate::` import paths
* ran `rustfmt`
* bumped to `v3.1.2`